### PR TITLE
Use env-based print URL in driver card list

### DIFF
--- a/routes/driverCards.js
+++ b/routes/driverCards.js
@@ -17,7 +17,8 @@ router.get('/driver-cards', asyncHandler(async (req, res) => {
   res.render('drivercards/index', {
     cards,
     title: 'بطاقات السائقين',
-    header: 'إدارة بطاقات السائقين'
+    header: 'إدارة بطاقات السائقين',
+    printUrl: process.env.PRINT_DRIVER_URL
   });
 }));
 

--- a/views/drivercards/index.ejs
+++ b/views/drivercards/index.ejs
@@ -16,7 +16,7 @@
   <tbody>
     <% cards.forEach(c => { %>
       <tr>
-        <td><pre class="codebox"><a href="https://s.mnaseb.com/h/OPcard/driver.php?token=<%= c.token %>" target="_blank"><%= c.CardNumber %></a></pre></td>
+        <td><pre class="codebox"><a href="<%= printUrl %>?token=<%= c.token %>" target="_blank"><%= c.CardNumber %></a></pre></td>
         <td><pre class="codebox"><%= c.CardType %></pre></td>
         <td><pre class="codebox"><%= c.FirstName || '' %></pre></td>
         <td><pre class="codebox"><%= c.Name || '' %></pre></td>


### PR DESCRIPTION
## Summary
- expose `PRINT_DRIVER_URL` when listing driver cards
- use the provided URL in driver card table

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d2d1783488331881fd5c10fe90f0b