### PR TITLE
Fix driver/vehicle selection after facility change

### DIFF
--- a/public/js/forms.js
+++ b/public/js/forms.js
@@ -63,7 +63,13 @@ $(function () {
       const dSel = $('select[name="DriverID"]');
       if (dSel.length) {
         dSel.empty();
-        data.forEach(d => dSel.append(`<option value="${d.DriverID}">${d.FirstName} ${d.LastName} - ${d.IdentityNumber || ''}</option>`));
+        data.forEach(d =>
+          dSel.append(`<option value="${d.DriverID}">${d.FirstName} ${d.LastName} - ${d.IdentityNumber || ''}</option>`)
+        );
+        const hidden = $('#driverHidden');
+        if (hidden.length && hidden.val()) {
+          dSel.val(hidden.val());
+        }
         dSel.trigger('change');
       }
     });
@@ -71,7 +77,13 @@ $(function () {
       const vSel = $('select[name="VehicleID"]');
       if (vSel.length) {
         vSel.empty();
-        data.forEach(v => vSel.append(`<option value="${v.ID}">${v.PlateNumber || v.SerialNumber}</option>`));
+        data.forEach(v =>
+          vSel.append(`<option value="${v.ID}">${v.PlateNumber || v.SerialNumber}</option>`)
+        );
+        const hidden = $('#vehicleHidden');
+        if (hidden.length && hidden.val()) {
+          vSel.val(hidden.val());
+        }
         vSel.trigger('change');
       }
     });

--- a/views/cards/new.ejs
+++ b/views/cards/new.ejs
@@ -21,6 +21,7 @@
       </select>
       <a href="#" target="_blank" id="addVehicleBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
     </div>
+    <input type="hidden" id="vehicleHidden" value="<%= card ? card.VehicleID : '' %>">
   </div>
   <div class="mb-3">
     <label class="form-label">تاريخ الإصدار</label>

--- a/views/drivercards/form.ejs
+++ b/views/drivercards/form.ejs
@@ -41,6 +41,7 @@
       <a href="#" target="_blank" id="addDriverBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
       <% } %>
       <% if (lockDriver) { %><input type="hidden" name="DriverID" value="<%= driver.DriverID %>"><% } %>
+      <input type="hidden" id="driverHidden" value="<%= card ? card.DriverID : (driver ? driver.DriverID : '') %>">
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- preserve selected driver when reloading driver list in forms
- preserve selected vehicle when reloading vehicle list in forms
- expose hidden fields to store the selected driver and vehicle

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d2df73790833196d84d6e0ab43e1b