### PR TITLE
feat: add multi-step card creation flow

### DIFF
--- a/views/cards/form.ejs
+++ b/views/cards/form.ejs
@@ -1,0 +1,59 @@
+<div class="card card-form">
+<form method="POST" action="<%= card ? '/nagl/cards/' + card.ID : '/nagl/cards' %>">
+  <h5 class="mb-3">معلومات البطاقة</h5>
+  <div class="mb-3">
+    <label class="form-label">تاريخ الإصدار</label>
+    <input type="text" name="IssueDate" class="form-control hijri-date" value="<%= card ? card.IssueDate : '' %>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">تاريخ الانتهاء</label>
+    <input type="text" name="ExpirationDate" class="form-control hijri-date" value="<%= card ? card.ExpirationDate : '' %>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">تاريخ التجديد</label>
+    <input type="text" name="RenewalDate" class="form-control hijri-date" value="<%= card ? card.RenewalDate || '' : '' %>">
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">المنشأة</label>
+    <div class="input-group">
+      <select name="FacilityID" class="custom-select select2" required <%= lockFacility ? 'disabled' : '' %>>
+        <% facilities.forEach(f => { %>
+          <option value="<%= f.FacilityID %>" <%= (card && card.FacilityID === f.FacilityID) || (facility && facility.FacilityID === f.FacilityID) ? 'selected' : '' %>><%= f.Name %> - <%= f.IdentityNumber %> - <%= f.LicenseType || '' %></option>
+        <% }) %>
+      </select>
+      <% if (!lockFacility) { %>
+      <a href="/nagl/facilities/new" target="_blank" id="addFacilityBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+      <% } %>
+      <% if (lockFacility) { %><input type="hidden" name="FacilityID" value="<%= facility.FacilityID %>"><% } %>
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">المركبة</label>
+    <div class="input-group">
+      <select name="VehicleID" class="custom-select select2" required <%= lockVehicle ? 'disabled' : '' %>>
+        <% vehicles.forEach(v => { %>
+          <option value="<%= v.ID %>" <%= (card && card.VehicleID === v.ID) || (vehicle && vehicle.ID === v.ID) ? 'selected' : '' %>><%= v.PlateNumber || v.SerialNumber %></option>
+        <% }) %>
+      </select>
+      <% if (!lockVehicle) { %>
+      <a href="#" target="_blank" id="addVehicleBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+      <% } %>
+      <% if (lockVehicle) { %><input type="hidden" name="VehicleID" value="<%= vehicle.ID %>"><% } %>
+      <input type="hidden" id="vehicleHidden" value="<%= card ? card.VehicleID : (vehicle ? vehicle.ID : '') %>">
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label">المورد</label>
+    <select name="Supplier" class="custom-select select2">
+      <% suppliers.forEach(s => { %>
+        <option value="<%= s.id %>" <%= card && card.Supplier === s.id ? 'selected' : '' %>><%= s.name %></option>
+      <% }) %>
+    </select>
+  </div>
+
+  <button type="submit" class="btn btn-success">حفظ</button>
+</form>
+</div>

--- a/views/cards/new.ejs
+++ b/views/cards/new.ejs
@@ -1,48 +1,9 @@
 <div class="card card-form">
-<form method="POST" action="<%= card ? '/nagl/cards/' + card.ID : '/nagl/cards' %>">
+<form method="POST" action="/nagl/cards/new">
   <div class="mb-3">
-    <label class="form-label">المنشأة</label>
-    <div class="input-group">
-      <select name="FacilityID" class="custom-select select2" required>
-        <% facilities.forEach(f => { %>
-          <option value="<%= f.FacilityID %>" <%= card && card.FacilityID === f.FacilityID ? 'selected' : '' %>><%= f.Name %> - <%= f.IdentityNumber %> - <%= f.LicenseType || '' %></option>
-        <% }) %>
-      </select>
-      <a href="/nagl/facilities/new" target="_blank" id="addFacilityBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
-    </div>
+    <label class="form-label">رقم هوية المنشأة</label>
+    <input type="text" name="IdentityNumber" class="form-control" required>
   </div>
-  <div class="mb-3">
-    <label class="form-label">المركبة</label>
-    <div class="input-group">
-      <select name="VehicleID" class="custom-select select2" required>
-        <% vehicles.forEach(v => { %>
-          <option value="<%= v.ID %>" <%= card && card.VehicleID === v.ID ? 'selected' : '' %>><%= v.PlateNumber || v.SerialNumber %></option>
-        <% }) %>
-      </select>
-      <a href="#" target="_blank" id="addVehicleBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
-    </div>
-    <input type="hidden" id="vehicleHidden" value="<%= card ? card.VehicleID : '' %>">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ الإصدار</label>
-    <input type="text" name="IssueDate" class="form-control hijri-date" value="<%= card ? card.IssueDate : '' %>">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ الانتهاء</label>
-    <input type="text" name="ExpirationDate" class="form-control hijri-date" value="<%= card ? card.ExpirationDate : '' %>">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ التجديد</label>
-    <input type="text" name="RenewalDate" class="form-control hijri-date" value="<%= card ? card.RenewalDate || '' : '' %>">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">المورد</label>
-    <select name="Supplier" class="custom-select select2">
-      <% suppliers.forEach(s => { %>
-        <option value="<%= s.id %>" <%= card && card.Supplier === s.id ? 'selected' : '' %>><%= s.name %></option>
-      <% }) %>
-    </select>
-  </div>
-  <button type="submit" class="btn btn-success">حفظ</button>
+  <button type="submit" class="btn btn-primary">متابعة</button>
 </form>
 </div>

--- a/views/cards/vehicle.ejs
+++ b/views/cards/vehicle.ejs
@@ -1,0 +1,13 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/cards/new/<%= facilityId %>/vehicle">
+  <div class="mb-3">
+    <label class="form-label">المنشأة</label>
+    <input type="text" class="form-control" value="<%= facilityName %>" readonly>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">الرقم التسلسلي للمركبة</label>
+    <input type="text" name="SerialNumber" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-primary">متابعة</button>
+</form>
+</div>


### PR DESCRIPTION
## Summary
- add step-based creation for cards with facility and vehicle lookups
- include views for facility, vehicle, and locked card form
- redirect to existing card or vehicle creation when needed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e77e6dd5883318f781a340de61ed0