### PR TITLE
Update brand, color, and model queries to new schema

### DIFF
--- a/routes/cards.js
+++ b/routes/cards.js
@@ -76,8 +76,8 @@ router.post('/cards/new/:facilityId/vehicle', asyncHandler(async (req, res) => {
     }
     return res.redirect(`/nagl/cards/new/${facilityId}/vehicle/${vehicleId}`);
   }
-  const brands = await pool.query('SELECT ID, Name FROM OPC_VehicleBrand');
-  const colors = await pool.query('SELECT ID, Name FROM OPC_VehicleColor');
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand');
+  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color');
   res.render('vehicles/new', {
     facilities: [],
     brands,

--- a/routes/vehicles.js
+++ b/routes/vehicles.js
@@ -18,8 +18,8 @@ router.get('/vehicles', asyncHandler(async (req, res) => {
 // New vehicle form
 router.get('/vehicles/new', asyncHandler(async (req, res) => {
   const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility');
-  const brands = await pool.query('SELECT ID, Name FROM OPC_VehicleBrand');
-  const colors = await pool.query('SELECT ID, Name FROM OPC_VehicleColor');
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand');
+  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color');
   const { facilityId = '', serialNumber = '', next = '' } = req.query;
   res.render('vehicles/new', {
     facilities,
@@ -65,8 +65,8 @@ router.get('/api/vehicles', asyncHandler(async (req, res) => {
 router.get('/api/vehicle-models', asyncHandler(async (req, res) => {
   const { brandId } = req.query;
   const models = brandId
-    ? await pool.query('SELECT ID, Name FROM OPC_VehicleModel WHERE BrandID = ?', [brandId])
-    : await pool.query('SELECT ID, Name FROM OPC_VehicleModel');
+    ? await pool.query('SELECT ModelID, ModelName FROM OPC_Model WHERE BrandID = ?', [brandId])
+    : await pool.query('SELECT ModelID, ModelName FROM OPC_Model');
   res.json(models);
 }));
 


### PR DESCRIPTION
## Summary
- query new OPC_Brand and OPC_Color tables for vehicle creation
- fetch models from OPC_Model via BrandID in API endpoint
- align card workflow with new brand and color tables

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f990369c083318ade3178b55d405f