### PR TITLE
feat: capture facility license details

### DIFF
--- a/routes/facilities.js
+++ b/routes/facilities.js
@@ -16,21 +16,48 @@ router.get('/facilities', asyncHandler(async (req, res) => {
 }));
 
 // New facility form
-router.get('/facilities/new', (req, res) => {
+router.get('/facilities/new', asyncHandler(async (req, res) => {
+  const licenseTypes = await pool.query(
+    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeNameAR'
+  );
   res.render('facilities/new', {
     identity: req.query.identity || '',
     next: req.query.next || '',
+    licenseTypes,
     title: 'إضافة منشأة',
     header: 'إضافة منشأة'
   });
-});
+}));
 
 // Create facility
 router.post('/facilities', asyncHandler(async (req, res) => {
-  const { IdentityNumber, Name, EnglishName, next } = req.body;
+  const {
+    IdentityNumber,
+    Name,
+    EnglishName,
+    LicenseNumber,
+    LicenseTypeID,
+    LicenseType,
+    LicenseCity,
+    LicenseCityEn,
+    LicenseIssueDate,
+    LicenseExpirationDate,
+    next
+  } = req.body;
   const result = await pool.query(
-    'INSERT INTO OPC_Facility (IdentityNumber, Name, EnglishName) VALUES (?, ?, ?)',
-    [IdentityNumber, Name, EnglishName || null]
+    'INSERT INTO OPC_Facility (IdentityNumber, Name, EnglishName, LicenseNumber, LicenseTypeID, LicenseType, LicenseCity, LicenseCityEn, LicenseIssueDate, LicenseExpirationDate) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+    [
+      IdentityNumber,
+      Name,
+      EnglishName || null,
+      LicenseNumber || null,
+      LicenseTypeID || null,
+      LicenseType || null,
+      LicenseCity || null,
+      LicenseCityEn || null,
+      LicenseIssueDate || null,
+      LicenseExpirationDate || null
+    ]
   );
   const fid = result.insertId;
   const redirectTo = next ? `${next}/${fid}/driver` : '/nagl/facilities';

--- a/views/facilities/new.ejs
+++ b/views/facilities/new.ejs
@@ -13,6 +13,45 @@
     <label class="form-label">الاسم بالإنجليزية</label>
     <input type="text" name="EnglishName" class="form-control">
   </div>
+  <div class="mb-3">
+    <label class="form-label">رقم الترخيص</label>
+    <input type="text" name="LicenseNumber" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">نوع الترخيص</label>
+    <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
+      <% licenseTypes.forEach(lt => { %>
+        <option value="<%= lt.LicenseTypeID %>" data-name="<%= lt.LicenseTypeNameAR %>"><%= lt.LicenseTypeNameAR %></option>
+      <% }) %>
+    </select>
+    <input type="hidden" name="LicenseType" id="LicenseType">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">مدينة الترخيص</label>
+    <input type="text" name="LicenseCity" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">مدينة الترخيص بالإنجليزية</label>
+    <input type="text" name="LicenseCityEn" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">تاريخ إصدار الترخيص</label>
+    <input type="date" name="LicenseIssueDate" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">تاريخ انتهاء الترخيص</label>
+    <input type="date" name="LicenseExpirationDate" class="form-control">
+  </div>
   <button type="submit" class="btn btn-success">متابعة</button>
 </form>
 </div>
+<script>
+  const licenseSelect = document.getElementById('LicenseTypeID');
+  const licenseTypeInput = document.getElementById('LicenseType');
+  function updateLicenseType() {
+    const selected = licenseSelect.options[licenseSelect.selectedIndex];
+    licenseTypeInput.value = selected ? selected.getAttribute('data-name') : '';
+  }
+  licenseSelect.addEventListener('change', updateLicenseType);
+  updateLicenseType();
+</script>


### PR DESCRIPTION
## Summary
- query license types for facility creation form
- add license-related fields to facility form and submission
- store license details when creating facilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fa4d971748331bb946d8c9c7844dd