### PR TITLE
Enable Hijri date picker for facility license fields

### DIFF
--- a/views/facilities/edit.ejs
+++ b/views/facilities/edit.ejs
@@ -17,6 +17,14 @@
     <input type="text" name="LicenseNumber" class="form-control" value="<%= facility.LicenseNumber || '' %>">
   </div>
   <div class="mb-3">
+    <label class="form-label">تاريخ إصدار الترخيص</label>
+    <input type="text" name="LicenseIssueDate" class="form-control hijri-date" value="<%= facility.LicenseIssueDate || '' %>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">تاريخ انتهاء الترخيص</label>
+    <input type="text" name="LicenseExpirationDate" class="form-control hijri-date" value="<%= facility.LicenseExpirationDate || '' %>">
+  </div>
+  <div class="mb-3">
     <label class="form-label">نوع الترخيص</label>
     <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
       <% licenseTypes.forEach(lt => { %>
@@ -32,14 +40,6 @@
   <div class="mb-3">
     <label class="form-label">مدينة الترخيص بالإنجليزية</label>
     <input type="text" name="LicenseCityEn" class="form-control" value="<%= facility.LicenseCityEn || '' %>">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ إصدار الترخيص</label>
-    <input type="date" name="LicenseIssueDate" class="form-control" value="<%= facility.LicenseIssueDate ? new Date(facility.LicenseIssueDate).toISOString().split('T')[0] : '' %>">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ انتهاء الترخيص</label>
-    <input type="date" name="LicenseExpirationDate" class="form-control" value="<%= facility.LicenseExpirationDate ? new Date(facility.LicenseExpirationDate).toISOString().split('T')[0] : '' %>">
   </div>
   <button type="submit" class="btn btn-success">تحديث</button>
 </form>

--- a/views/facilities/new.ejs
+++ b/views/facilities/new.ejs
@@ -18,6 +18,14 @@
     <input type="text" name="LicenseNumber" class="form-control">
   </div>
   <div class="mb-3">
+    <label class="form-label">تاريخ إصدار الترخيص</label>
+    <input type="text" name="LicenseIssueDate" class="form-control hijri-date">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">تاريخ انتهاء الترخيص</label>
+    <input type="text" name="LicenseExpirationDate" class="form-control hijri-date">
+  </div>
+  <div class="mb-3">
     <label class="form-label">نوع الترخيص</label>
     <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
       <% licenseTypes.forEach(lt => { %>
@@ -33,14 +41,6 @@
   <div class="mb-3">
     <label class="form-label">مدينة الترخيص بالإنجليزية</label>
     <input type="text" name="LicenseCityEn" class="form-control">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ إصدار الترخيص</label>
-    <input type="date" name="LicenseIssueDate" class="form-control">
-  </div>
-  <div class="mb-3">
-    <label class="form-label">تاريخ انتهاء الترخيص</label>
-    <input type="date" name="LicenseExpirationDate" class="form-control">
   </div>
   <button type="submit" class="btn btn-success">متابعة</button>
 </form>


### PR DESCRIPTION
## Summary
- show license issue and expiration fields immediately after license number
- use hijri date picker inputs when creating and editing facilities

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fb027d22c8331bbb308ea514ce075