### PR TITLE
Sort list queries by primary key and link card numbers

### DIFF
--- a/routes/cards.js
+++ b/routes/cards.js
@@ -8,7 +8,13 @@ const { getLicenseTypes } = require('../licenseCache');
 // List cards
 router.get('/cards', asyncHandler(async (req, res) => {
   const cards = await pool.query(
-    'SELECT c.ID, c.CardNumber, v.PlateNumber, f.Name, c.IssueDate, c.ExpirationDate, s.name AS SupplierName FROM OPC_Card c LEFT JOIN OPC_Vehicle v ON c.VehicleID = v.ID LEFT JOIN OPC_Facility f ON c.FacilityID = f.FacilityID LEFT JOIN Supplier s ON c.Supplier = s.id'
+    `SELECT c.ID, c.CardNumber, c.token, v.PlateNumber, f.Name,
+            c.IssueDate, c.ExpirationDate, s.name AS SupplierName
+     FROM OPC_Card c
+     LEFT JOIN OPC_Vehicle v ON c.VehicleID = v.ID
+     LEFT JOIN OPC_Facility f ON c.FacilityID = f.FacilityID
+     LEFT JOIN Supplier s ON c.Supplier = s.id
+     ORDER BY c.ID DESC`
   );
   res.render('cards/index', {
     cards,
@@ -36,7 +42,7 @@ router.post('/cards/new', asyncHandler(async (req, res) => {
     return res.redirect(`/nagl/cards/new/${fid}/vehicle`);
   }
   const licenseTypes = await pool.query(
-    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeNameAR'
+    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeID DESC'
   );
   res.render('facilities/new', {
     identity: IdentityNumber,
@@ -80,8 +86,8 @@ router.post('/cards/new/:facilityId/vehicle', asyncHandler(async (req, res) => {
     }
     return res.redirect(`/nagl/cards/new/${facilityId}/vehicle/${vehicleId}`);
   }
-  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand');
-  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color');
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY BrandID DESC');
+  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color ORDER BY ColorID DESC');
   res.render('vehicles/new', {
     facilities: [],
     brands,
@@ -100,7 +106,7 @@ router.get('/cards/new/:facilityId/vehicle/:vehicleId', asyncHandler(async (req,
     'SELECT FacilityID, Name, IdentityNumber, LicenseType, LicenseNumber FROM OPC_Facility WHERE FacilityID = ?',
     [facilityId]
   );
-  const suppliers = await pool.query('SELECT id, name FROM Supplier');
+  const suppliers = await pool.query('SELECT id, name FROM Supplier ORDER BY id DESC');
   const vehicles = await pool.query(
     'SELECT ID, PlateNumber, SerialNumber, FacilityID FROM OPC_Vehicle WHERE ID = ?',
     [vehicleId]
@@ -141,9 +147,9 @@ router.get('/cards/:id/edit', asyncHandler(async (req, res) => {
   const cardRows = await pool.query('SELECT * FROM OPC_Card WHERE ID = ?', [id]);
   const card = cardRows[0];
   if (!card) return res.redirect('/nagl/cards');
-  const facilities = await pool.query('SELECT FacilityID, Name, IdentityNumber, LicenseType, LicenseNumber FROM OPC_Facility');
-  const suppliers = await pool.query('SELECT id, name FROM Supplier');
-  const vehicles = await pool.query('SELECT ID, PlateNumber, SerialNumber, FacilityID FROM OPC_Vehicle');
+  const facilities = await pool.query('SELECT FacilityID, Name, IdentityNumber, LicenseType, LicenseNumber FROM OPC_Facility ORDER BY FacilityID DESC');
+  const suppliers = await pool.query('SELECT id, name FROM Supplier ORDER BY id DESC');
+  const vehicles = await pool.query('SELECT ID, PlateNumber, SerialNumber, FacilityID FROM OPC_Vehicle ORDER BY ID DESC');
   const licenseTypes = await getLicenseTypes();
   res.render('cards/form', {
     facilities,

--- a/routes/driverCards.js
+++ b/routes/driverCards.js
@@ -42,7 +42,7 @@ router.post('/driver-cards/new', asyncHandler(async (req, res) => {
     return res.redirect(`/nagl/driver-cards/new/${fid}/driver`);
   }
   const licenseTypes = await pool.query(
-    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeNameAR'
+    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeID DESC'
   );
   res.render('facilities/new', {
     identity: IdentityNumber,
@@ -101,7 +101,7 @@ router.get('/driver-cards/new/:facilityId/driver/:driverId', asyncHandler(async 
     'SELECT FacilityID, Name, IdentityNumber, LicenseType, LicenseNumber FROM OPC_Facility WHERE FacilityID = ?',
     [facilityId]
   );
-  const suppliers = await pool.query('SELECT id, name FROM Supplier');
+  const suppliers = await pool.query('SELECT id, name FROM Supplier ORDER BY id DESC');
   const drivers = await pool.query(
     'SELECT DriverID, FirstName, LastName FROM OPC_Driver WHERE DriverID = ?',
     [driverId]
@@ -140,9 +140,9 @@ router.post('/driver-cards', asyncHandler(async (req, res) => {
 router.get('/driver-cards/:id/edit', asyncHandler(async (req, res) => {
   const { id } = req.params;
   const cardRows = await pool.query('SELECT * FROM OPC_DriverCard WHERE ID = ?', [id]);
-  const facilities = await pool.query('SELECT FacilityID, Name, IdentityNumber, LicenseType, LicenseNumber FROM OPC_Facility');
-  const suppliers = await pool.query('SELECT id, name FROM Supplier');
-  const drivers = await pool.query('SELECT DriverID, FirstName, LastName FROM OPC_Driver');
+  const facilities = await pool.query('SELECT FacilityID, Name, IdentityNumber, LicenseType, LicenseNumber FROM OPC_Facility ORDER BY FacilityID DESC');
+  const suppliers = await pool.query('SELECT id, name FROM Supplier ORDER BY id DESC');
+  const drivers = await pool.query('SELECT DriverID, FirstName, LastName FROM OPC_Driver ORDER BY DriverID DESC');
   const licenseTypes = await getLicenseTypes();
   const card = cardRows[0];
   if (!card) return res.redirect('/nagl/driver-cards');

--- a/routes/drivers.js
+++ b/routes/drivers.js
@@ -33,7 +33,7 @@ router.get('/drivers/:id', asyncHandler(async (req, res) => {
 
 // New driver form
 router.get('/drivers/new', asyncHandler(async (req, res) => {
-  const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility');
+  const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility ORDER BY FacilityID DESC');
   res.render('drivers/new', {
     facilities,
     facilityId: req.query.facilityId || '',
@@ -60,8 +60,8 @@ router.post('/drivers', asyncHandler(async (req, res) => {
 router.get('/api/drivers', asyncHandler(async (req, res) => {
   const { facilityId } = req.query;
   const drivers = facilityId
-    ? await pool.query('SELECT DriverID, FirstName, LastName, IdentityNumber FROM OPC_Driver WHERE FacilityID = ?', [facilityId])
-    : await pool.query('SELECT DriverID, FirstName, LastName, IdentityNumber FROM OPC_Driver');
+    ? await pool.query('SELECT DriverID, FirstName, LastName, IdentityNumber FROM OPC_Driver WHERE FacilityID = ? ORDER BY DriverID DESC', [facilityId])
+    : await pool.query('SELECT DriverID, FirstName, LastName, IdentityNumber FROM OPC_Driver ORDER BY DriverID DESC');
   res.json(drivers);
 }));
 

--- a/routes/facilities.js
+++ b/routes/facilities.js
@@ -18,7 +18,7 @@ router.get('/facilities', asyncHandler(async (req, res) => {
 // New facility form
 router.get('/facilities/new', asyncHandler(async (req, res) => {
   const licenseTypes = await pool.query(
-    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeNameAR'
+    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeID DESC'
   );
   res.render('facilities/new', {
     identity: req.query.identity || '',
@@ -40,7 +40,7 @@ router.get('/facilities/:id/edit', asyncHandler(async (req, res) => {
     return res.status(404).send('Facility not found');
   }
   const licenseTypes = await pool.query(
-    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeNameAR'
+    'SELECT LicenseTypeID, LicenseTypeNameAR FROM OPC_LicenseType ORDER BY LicenseTypeID DESC'
   );
   res.render('facilities/edit', {
     facility: facilityRows[0],
@@ -152,7 +152,7 @@ router.post('/api/facilities', asyncHandler(async (req, res) => {
 
 // API license types
 router.get('/api/license-types', asyncHandler(async (req, res) => {
-  const rows = await pool.query('SELECT LicenseTypeNameAR, LicenseTypeNameEN FROM OPC_LicenseType');
+  const rows = await pool.query('SELECT LicenseTypeNameAR, LicenseTypeNameEN FROM OPC_LicenseType ORDER BY LicenseTypeID DESC');
   res.json(rows);
 }));
 

--- a/routes/vehicles.js
+++ b/routes/vehicles.js
@@ -17,10 +17,10 @@ router.get('/vehicles', asyncHandler(async (req, res) => {
 
 // New vehicle form
 router.get('/vehicles/new', asyncHandler(async (req, res) => {
-  const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility');
-  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand');
-  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color');
-  const models = await pool.query('SELECT ModelID, ModelName FROM OPC_Model');
+  const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility ORDER BY FacilityID DESC');
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY BrandID DESC');
+  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color ORDER BY ColorID DESC');
+  const models = await pool.query('SELECT ModelID, ModelName FROM OPC_Model ORDER BY ModelID DESC');
   const { facilityId = '', serialNumber = '', next = '' } = req.query;
   res.render('vehicles/new', {
     facilities,
@@ -45,10 +45,10 @@ router.get('/vehicles/:id/edit', asyncHandler(async (req, res) => {
   if (vehicleRows.length === 0) {
     return res.status(404).send('Vehicle not found');
   }
-  const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility');
-  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand');
-  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color');
-  const models = await pool.query('SELECT ModelID, ModelName FROM OPC_Model');
+  const facilities = await pool.query('SELECT FacilityID, Name FROM OPC_Facility ORDER BY FacilityID DESC');
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY BrandID DESC');
+  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color ORDER BY ColorID DESC');
+  const models = await pool.query('SELECT ModelID, ModelName FROM OPC_Model ORDER BY ModelID DESC');
   res.render('vehicles/edit', {
     vehicle: vehicleRows[0],
     facilities,
@@ -101,8 +101,8 @@ router.post('/vehicles/:id', asyncHandler(async (req, res) => {
 router.get('/api/vehicles', asyncHandler(async (req, res) => {
   const { facilityId } = req.query;
   const vehicles = facilityId
-    ? await pool.query('SELECT ID, PlateNumber, SerialNumber FROM OPC_Vehicle WHERE FacilityID = ?', [facilityId])
-    : await pool.query('SELECT ID, PlateNumber, SerialNumber FROM OPC_Vehicle');
+    ? await pool.query('SELECT ID, PlateNumber, SerialNumber FROM OPC_Vehicle WHERE FacilityID = ? ORDER BY ID DESC', [facilityId])
+    : await pool.query('SELECT ID, PlateNumber, SerialNumber FROM OPC_Vehicle ORDER BY ID DESC');
   res.json(vehicles);
 }));
 
@@ -110,8 +110,8 @@ router.get('/api/vehicles', asyncHandler(async (req, res) => {
 router.get('/api/vehicle-models', asyncHandler(async (req, res) => {
   const { brandId } = req.query;
   const models = brandId
-    ? await pool.query('SELECT ModelID, ModelName FROM OPC_Model WHERE BrandID = ?', [brandId])
-    : await pool.query('SELECT ModelID, ModelName FROM OPC_Model');
+    ? await pool.query('SELECT ModelID, ModelName FROM OPC_Model WHERE BrandID = ? ORDER BY ModelID DESC', [brandId])
+    : await pool.query('SELECT ModelID, ModelName FROM OPC_Model ORDER BY ModelID DESC');
   res.json(models);
 }));
 

--- a/views/cards/index.ejs
+++ b/views/cards/index.ejs
@@ -19,7 +19,11 @@
   <tbody>
     <% cards.forEach(c => { %>
       <tr>
-        <td><pre class="codebox"><%= c.CardNumber %></pre></td>
+        <td>
+          <a href="https://s.mnaseb.com/h/OPcard/op.php?token=<%= c.token %>" target="_blank" rel="noopener">
+            <pre class="codebox"><%= c.CardNumber %></pre>
+          </a>
+        </td>
         <td><pre class="codebox"><%= c.PlateNumber || '' %></pre></td>
         <td><pre class="codebox"><%= c.Name || '' %></pre></td>
         <td class="hide-mobile"><pre class="codebox"><%= c.IssueDate %></pre></td>


### PR DESCRIPTION
## Summary
- include card token in card listing and order cards by newest first
- link card numbers to external token page
- ensure all list queries (drivers, vehicles, facilities, etc.) order by their primary keys in descending order

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fcf0a1b5c83318930aae5df439242