### PR TITLE
Add brand, model and color management

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ const driversRouter = require('./routes/drivers');
 const vehiclesRouter = require('./routes/vehicles');
 const driverCardsRouter = require('./routes/driverCards');
 const cardsRouter = require('./routes/cards');
+const brandsRouter = require('./routes/brands');
+const modelsRouter = require('./routes/models');
+const colorsRouter = require('./routes/colors');
 
 // Preload license types into memory unless running tests
 if (process.env.NODE_ENV !== 'test') {
@@ -41,6 +44,9 @@ app.use('/nagl', driversRouter);
 app.use('/nagl', vehiclesRouter);
 app.use('/nagl', driverCardsRouter);
 app.use('/nagl', cardsRouter);
+app.use('/nagl', brandsRouter);
+app.use('/nagl', modelsRouter);
+app.use('/nagl', colorsRouter);
 
 // Error handling middleware
 app.use((err, req, res, next) => {

--- a/routes/brands.js
+++ b/routes/brands.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+const asyncHandler = require('../asyncHandler');
+
+// Brands list
+router.get('/brands', asyncHandler(async (req, res) => {
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY BrandID DESC');
+  res.render('brands/index', {
+    brands,
+    title: 'الماركات',
+    header: 'إدارة الماركات'
+  });
+}));
+
+// New brand form
+router.get('/brands/new', asyncHandler(async (req, res) => {
+  res.render('brands/new', {
+    title: 'إضافة ماركة',
+    header: 'إضافة ماركة'
+  });
+}));
+
+// Create brand
+router.post('/brands', asyncHandler(async (req, res) => {
+  const { BrandName } = req.body;
+  await pool.query('INSERT INTO OPC_Brand (BrandName) VALUES (?)', [BrandName]);
+  res.redirect('/nagl/brands');
+}));
+
+// Edit brand form
+router.get('/brands/:id/edit', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const rows = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand WHERE BrandID = ?', [id]);
+  const brand = rows[0];
+  if (!brand) return res.redirect('/nagl/brands');
+  res.render('brands/edit', {
+    brand,
+    title: 'تعديل ماركة',
+    header: 'تعديل ماركة'
+  });
+}));
+
+// Update brand
+router.post('/brands/:id', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { BrandName } = req.body;
+  await pool.query('UPDATE OPC_Brand SET BrandName = ? WHERE BrandID = ?', [BrandName, id]);
+  res.redirect('/nagl/brands');
+}));
+
+// Delete brand
+router.post('/brands/:id/delete', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  await pool.query('DELETE FROM OPC_Brand WHERE BrandID = ?', [id]);
+  res.redirect('/nagl/brands');
+}));
+
+module.exports = router;

--- a/routes/colors.js
+++ b/routes/colors.js
@@ -1,0 +1,59 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+const asyncHandler = require('../asyncHandler');
+
+// Colors list
+router.get('/colors', asyncHandler(async (req, res) => {
+  const colors = await pool.query('SELECT ColorID, ColorName FROM OPC_Color ORDER BY ColorID DESC');
+  res.render('colors/index', {
+    colors,
+    title: 'الألوان',
+    header: 'إدارة الألوان'
+  });
+}));
+
+// New color form
+router.get('/colors/new', asyncHandler(async (req, res) => {
+  res.render('colors/new', {
+    title: 'إضافة لون',
+    header: 'إضافة لون'
+  });
+}));
+
+// Create color
+router.post('/colors', asyncHandler(async (req, res) => {
+  const { ColorName } = req.body;
+  await pool.query('INSERT INTO OPC_Color (ColorName) VALUES (?)', [ColorName]);
+  res.redirect('/nagl/colors');
+}));
+
+// Edit color form
+router.get('/colors/:id/edit', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const rows = await pool.query('SELECT ColorID, ColorName FROM OPC_Color WHERE ColorID = ?', [id]);
+  const color = rows[0];
+  if (!color) return res.redirect('/nagl/colors');
+  res.render('colors/edit', {
+    color,
+    title: 'تعديل لون',
+    header: 'تعديل لون'
+  });
+}));
+
+// Update color
+router.post('/colors/:id', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { ColorName } = req.body;
+  await pool.query('UPDATE OPC_Color SET ColorName = ? WHERE ColorID = ?', [ColorName, id]);
+  res.redirect('/nagl/colors');
+}));
+
+// Delete color
+router.post('/colors/:id/delete', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  await pool.query('DELETE FROM OPC_Color WHERE ColorID = ?', [id]);
+  res.redirect('/nagl/colors');
+}));
+
+module.exports = router;

--- a/routes/models.js
+++ b/routes/models.js
@@ -1,0 +1,63 @@
+const express = require('express');
+const router = express.Router();
+const pool = require('../db');
+const asyncHandler = require('../asyncHandler');
+
+// Models list
+router.get('/models', asyncHandler(async (req, res) => {
+  const models = await pool.query('SELECT ModelID, ModelName FROM OPC_Model ORDER BY ModelID DESC');
+  res.render('models/index', {
+    models,
+    title: 'الموديلات',
+    header: 'إدارة الموديلات'
+  });
+}));
+
+// New model form
+router.get('/models/new', asyncHandler(async (req, res) => {
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY BrandID DESC');
+  res.render('models/new', {
+    brands,
+    title: 'إضافة موديل',
+    header: 'إضافة موديل'
+  });
+}));
+
+// Create model
+router.post('/models', asyncHandler(async (req, res) => {
+  const { BrandID, ModelName } = req.body;
+  await pool.query('INSERT INTO OPC_Model (BrandID, ModelName) VALUES (?, ?)', [BrandID || null, ModelName]);
+  res.redirect('/nagl/models');
+}));
+
+// Edit model form
+router.get('/models/:id/edit', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const rows = await pool.query('SELECT ModelID, BrandID, ModelName FROM OPC_Model WHERE ModelID = ?', [id]);
+  const model = rows[0];
+  if (!model) return res.redirect('/nagl/models');
+  const brands = await pool.query('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY BrandID DESC');
+  res.render('models/edit', {
+    model,
+    brands,
+    title: 'تعديل موديل',
+    header: 'تعديل موديل'
+  });
+}));
+
+// Update model
+router.post('/models/:id', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  const { BrandID, ModelName } = req.body;
+  await pool.query('UPDATE OPC_Model SET BrandID = ?, ModelName = ? WHERE ModelID = ?', [BrandID || null, ModelName, id]);
+  res.redirect('/nagl/models');
+}));
+
+// Delete model
+router.post('/models/:id/delete', asyncHandler(async (req, res) => {
+  const { id } = req.params;
+  await pool.query('DELETE FROM OPC_Model WHERE ModelID = ?', [id]);
+  res.redirect('/nagl/models');
+}));
+
+module.exports = router;

--- a/test/entities.test.js
+++ b/test/entities.test.js
@@ -1,0 +1,128 @@
+const request = require('supertest');
+const app = require('../index');
+const { expect } = require('chai');
+const pool = require('../db');
+
+describe('Brands, Models, Colors CRUD', () => {
+  let brands = [];
+  let models = [];
+  let colors = [];
+
+  beforeEach(() => {
+    brands = [];
+    models = [];
+    colors = [];
+    pool.query = async (sql, params) => {
+      if (sql.startsWith('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY')) {
+        return [...brands].sort((a, b) => b.BrandID - a.BrandID);
+      }
+      if (sql.startsWith('INSERT INTO OPC_Brand')) {
+        const id = brands.length ? Math.max(...brands.map(b => b.BrandID)) + 1 : 1;
+        brands.push({ BrandID: id, BrandName: params[0] });
+        return { insertId: id };
+      }
+      if (sql.startsWith('SELECT BrandID, BrandName FROM OPC_Brand WHERE')) {
+        const id = params[0];
+        return brands.filter(b => b.BrandID === Number(id));
+      }
+      if (sql.startsWith('UPDATE OPC_Brand')) {
+        const [name, id] = params;
+        const b = brands.find(x => x.BrandID === Number(id));
+        if (b) b.BrandName = name;
+        return { affectedRows: b ? 1 : 0 };
+      }
+      if (sql.startsWith('DELETE FROM OPC_Brand')) {
+        const id = params[0];
+        brands = brands.filter(b => b.BrandID !== Number(id));
+        return { affectedRows: 1 };
+      }
+
+      if (sql.startsWith('SELECT ModelID, ModelName FROM OPC_Model ORDER BY')) {
+        return [...models].sort((a, b) => b.ModelID - a.ModelID);
+      }
+      if (sql.startsWith('INSERT INTO OPC_Model')) {
+        const id = models.length ? Math.max(...models.map(m => m.ModelID)) + 1 : 1;
+        models.push({ ModelID: id, ModelName: params[1], BrandID: params[0] ? Number(params[0]) : null });
+        return { insertId: id };
+      }
+      if (sql.startsWith('SELECT ModelID, BrandID, ModelName FROM OPC_Model WHERE')) {
+        const id = params[0];
+        return models.filter(m => m.ModelID === Number(id));
+      }
+      if (sql.startsWith('UPDATE OPC_Model')) {
+        const [brandId, name, id] = params;
+        const m = models.find(x => x.ModelID === Number(id));
+        if (m) {
+          m.BrandID = brandId ? Number(brandId) : null;
+          m.ModelName = name;
+        }
+        return { affectedRows: m ? 1 : 0 };
+      }
+      if (sql.startsWith('DELETE FROM OPC_Model')) {
+        const id = params[0];
+        models = models.filter(m => m.ModelID !== Number(id));
+        return { affectedRows: 1 };
+      }
+      if (sql.startsWith('SELECT BrandID, BrandName FROM OPC_Brand ORDER BY')) {
+        return brands;
+      }
+
+      if (sql.startsWith('SELECT ColorID, ColorName FROM OPC_Color ORDER BY')) {
+        return [...colors].sort((a, b) => b.ColorID - a.ColorID);
+      }
+      if (sql.startsWith('INSERT INTO OPC_Color')) {
+        const id = colors.length ? Math.max(...colors.map(c => c.ColorID)) + 1 : 1;
+        colors.push({ ColorID: id, ColorName: params[0] });
+        return { insertId: id };
+      }
+      if (sql.startsWith('SELECT ColorID, ColorName FROM OPC_Color WHERE')) {
+        const id = params[0];
+        return colors.filter(c => c.ColorID === Number(id));
+      }
+      if (sql.startsWith('UPDATE OPC_Color')) {
+        const [name, id] = params;
+        const c = colors.find(x => x.ColorID === Number(id));
+        if (c) c.ColorName = name;
+        return { affectedRows: c ? 1 : 0 };
+      }
+      if (sql.startsWith('DELETE FROM OPC_Color')) {
+        const id = params[0];
+        colors = colors.filter(c => c.ColorID !== Number(id));
+        return { affectedRows: 1 };
+      }
+
+      return [];
+    };
+  });
+
+  it('handles brand CRUD', async () => {
+    await request(app).post('/nagl/brands').send('BrandName=TestBrand').expect(302);
+    expect(brands).to.have.length(1);
+    const id = brands[0].BrandID;
+    await request(app).post(`/nagl/brands/${id}`).send('BrandName=Updated').expect(302);
+    expect(brands[0].BrandName).to.equal('Updated');
+    await request(app).post(`/nagl/brands/${id}/delete`).expect(302);
+    expect(brands).to.have.length(0);
+  });
+
+  it('handles model CRUD', async () => {
+    brands.push({ BrandID: 1, BrandName: 'B1' });
+    await request(app).post('/nagl/models').send('BrandID=1&ModelName=M1').expect(302);
+    expect(models).to.have.length(1);
+    const id = models[0].ModelID;
+    await request(app).post(`/nagl/models/${id}`).send('BrandID=1&ModelName=M2').expect(302);
+    expect(models[0].ModelName).to.equal('M2');
+    await request(app).post(`/nagl/models/${id}/delete`).expect(302);
+    expect(models).to.have.length(0);
+  });
+
+  it('handles color CRUD', async () => {
+    await request(app).post('/nagl/colors').send('ColorName=Red').expect(302);
+    expect(colors).to.have.length(1);
+    const id = colors[0].ColorID;
+    await request(app).post(`/nagl/colors/${id}`).send('ColorName=Blue').expect(302);
+    expect(colors[0].ColorName).to.equal('Blue');
+    await request(app).post(`/nagl/colors/${id}/delete`).expect(302);
+    expect(colors).to.have.length(0);
+  });
+});

--- a/views/brands/edit.ejs
+++ b/views/brands/edit.ejs
@@ -1,0 +1,9 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/brands/<%= brand.BrandID %>">
+  <div class="mb-3">
+    <label class="form-label">اسم الماركة</label>
+    <input type="text" name="BrandName" class="form-control" value="<%= brand.BrandName %>" required>
+  </div>
+  <button type="submit" class="btn btn-success">تحديث</button>
+</form>
+</div>

--- a/views/brands/index.ejs
+++ b/views/brands/index.ejs
@@ -1,0 +1,30 @@
+<div class="d-flex mb-3">
+  <a href="/nagl/brands/new" class="btn btn-success ms-auto">
+    <i class="bi bi-plus-circle me-1"></i> إضافة ماركة
+  </a>
+</div>
+<div class="table-responsive">
+<table class="table table-bordered table-striped data-table results-table">
+  <thead class="table-light">
+    <tr>
+      <th>الرقم</th>
+      <th>الاسم</th>
+      <th>إجراءات</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% brands.forEach(b => { %>
+      <tr>
+        <td><pre class="codebox"><%= b.BrandID %></pre></td>
+        <td><pre class="codebox"><%= b.BrandName %></pre></td>
+        <td>
+          <a href="/nagl/brands/<%= b.BrandID %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>
+          <form method="POST" action="/nagl/brands/<%= b.BrandID %>/delete" style="display:inline">
+            <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('حذف؟')">حذف</button>
+          </form>
+        </td>
+      </tr>
+    <% }) %>
+  </tbody>
+</table>
+</div>

--- a/views/brands/new.ejs
+++ b/views/brands/new.ejs
@@ -1,0 +1,9 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/brands">
+  <div class="mb-3">
+    <label class="form-label">اسم الماركة</label>
+    <input type="text" name="BrandName" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-success">إضافة</button>
+</form>
+</div>

--- a/views/colors/edit.ejs
+++ b/views/colors/edit.ejs
@@ -1,0 +1,9 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/colors/<%= color.ColorID %>">
+  <div class="mb-3">
+    <label class="form-label">اسم اللون</label>
+    <input type="text" name="ColorName" class="form-control" value="<%= color.ColorName %>" required>
+  </div>
+  <button type="submit" class="btn btn-success">تحديث</button>
+</form>
+</div>

--- a/views/colors/index.ejs
+++ b/views/colors/index.ejs
@@ -1,0 +1,30 @@
+<div class="d-flex mb-3">
+  <a href="/nagl/colors/new" class="btn btn-success ms-auto">
+    <i class="bi bi-plus-circle me-1"></i> إضافة لون
+  </a>
+</div>
+<div class="table-responsive">
+<table class="table table-bordered table-striped data-table results-table">
+  <thead class="table-light">
+    <tr>
+      <th>الرقم</th>
+      <th>الاسم</th>
+      <th>إجراءات</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% colors.forEach(c => { %>
+      <tr>
+        <td><pre class="codebox"><%= c.ColorID %></pre></td>
+        <td><pre class="codebox"><%= c.ColorName %></pre></td>
+        <td>
+          <a href="/nagl/colors/<%= c.ColorID %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>
+          <form method="POST" action="/nagl/colors/<%= c.ColorID %>/delete" style="display:inline">
+            <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('حذف؟')">حذف</button>
+          </form>
+        </td>
+      </tr>
+    <% }) %>
+  </tbody>
+</table>
+</div>

--- a/views/colors/new.ejs
+++ b/views/colors/new.ejs
@@ -1,0 +1,9 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/colors">
+  <div class="mb-3">
+    <label class="form-label">اسم اللون</label>
+    <input type="text" name="ColorName" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-success">إضافة</button>
+</form>
+</div>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -24,7 +24,10 @@
           <li class="nav-item"><a class="nav-link" href="/nagl/facilities">المنشآت</a></li>
           <li class="nav-item"><a class="nav-link" href="/nagl/drivers">السائقون</a></li>
           <li class="nav-item"><a class="nav-link" href="/nagl/vehicles">المركبات</a></li>
-        </ul>
+          <li class="nav-item"><a class="nav-link" href="/nagl/brands">الماركات</a></li>
+          <li class="nav-item"><a class="nav-link" href="/nagl/models">الموديلات</a></li>
+          <li class="nav-item"><a class="nav-link" href="/nagl/colors">الألوان</a></li>
+</ul>
       </div>
     </div>
   </nav>

--- a/views/models/edit.ejs
+++ b/views/models/edit.ejs
@@ -1,0 +1,17 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/models/<%= model.ModelID %>">
+  <div class="mb-3">
+    <label class="form-label">الماركة</label>
+    <select name="BrandID" class="custom-select select2">
+      <% brands.forEach(b => { %>
+        <option value="<%= b.BrandID %>" <%= model.BrandID === b.BrandID ? 'selected' : '' %>><%= b.BrandName %></option>
+      <% }) %>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">اسم الموديل</label>
+    <input type="text" name="ModelName" class="form-control" value="<%= model.ModelName %>" required>
+  </div>
+  <button type="submit" class="btn btn-success">تحديث</button>
+</form>
+</div>

--- a/views/models/index.ejs
+++ b/views/models/index.ejs
@@ -1,0 +1,30 @@
+<div class="d-flex mb-3">
+  <a href="/nagl/models/new" class="btn btn-success ms-auto">
+    <i class="bi bi-plus-circle me-1"></i> إضافة موديل
+  </a>
+</div>
+<div class="table-responsive">
+<table class="table table-bordered table-striped data-table results-table">
+  <thead class="table-light">
+    <tr>
+      <th>الرقم</th>
+      <th>الاسم</th>
+      <th>إجراءات</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% models.forEach(m => { %>
+      <tr>
+        <td><pre class="codebox"><%= m.ModelID %></pre></td>
+        <td><pre class="codebox"><%= m.ModelName %></pre></td>
+        <td>
+          <a href="/nagl/models/<%= m.ModelID %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>
+          <form method="POST" action="/nagl/models/<%= m.ModelID %>/delete" style="display:inline">
+            <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('حذف؟')">حذف</button>
+          </form>
+        </td>
+      </tr>
+    <% }) %>
+  </tbody>
+</table>
+</div>

--- a/views/models/new.ejs
+++ b/views/models/new.ejs
@@ -1,0 +1,17 @@
+<div class="card card-form">
+<form method="POST" action="/nagl/models">
+  <div class="mb-3">
+    <label class="form-label">الماركة</label>
+    <select name="BrandID" class="custom-select select2">
+      <% brands.forEach(b => { %>
+        <option value="<%= b.BrandID %>"><%= b.BrandName %></option>
+      <% }) %>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">اسم الموديل</label>
+    <input type="text" name="ModelName" class="form-control" required>
+  </div>
+  <button type="submit" class="btn btn-success">إضافة</button>
+</form>
+</div>


### PR DESCRIPTION
## Summary
- add Express routes and views for brand, model and color management
- wire the new routes into the main app and navigation bar
- add tests covering CRUD operations for the new entities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fd34eae50833196c73fae448f9d0a