### PR TITLE
Add quick-create buttons beside select fields

### DIFF
--- a/views/cards/form.ejs
+++ b/views/cards/form.ejs
@@ -38,7 +38,7 @@
         <% }) %>
       </select>
       <% if (!lockVehicle) { %>
-      <a href="#" target="_blank" id="addVehicleBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+      <a href="/nagl/vehicles/new" target="_blank" id="addVehicleBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
       <% } %>
       <% if (lockVehicle) { %><input type="hidden" name="VehicleID" value="<%= vehicle.ID %>"><% } %>
       <input type="hidden" id="vehicleHidden" value="<%= card ? card.VehicleID : (vehicle ? vehicle.ID : '') %>">
@@ -47,11 +47,14 @@
 
   <div class="mb-3">
     <label class="form-label">المورد</label>
-    <select name="Supplier" class="custom-select select2">
-      <% suppliers.forEach(s => { %>
-        <option value="<%= s.id %>" <%= card && card.Supplier === s.id ? 'selected' : '' %>><%= s.name %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="Supplier" class="custom-select select2">
+        <% suppliers.forEach(s => { %>
+          <option value="<%= s.id %>" <%= card && card.Supplier === s.id ? 'selected' : '' %>><%= s.name %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/suppliers/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
 
   <button type="submit" class="btn btn-success">حفظ</button>

--- a/views/drivercards/form.ejs
+++ b/views/drivercards/form.ejs
@@ -38,7 +38,7 @@
         <% }) %>
       </select>
       <% if (!lockDriver) { %>
-      <a href="#" target="_blank" id="addDriverBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+      <a href="/nagl/drivers/new" target="_blank" id="addDriverBtn" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
       <% } %>
       <% if (lockDriver) { %><input type="hidden" name="DriverID" value="<%= driver.DriverID %>"><% } %>
       <input type="hidden" id="driverHidden" value="<%= card ? card.DriverID : (driver ? driver.DriverID : '') %>">
@@ -47,11 +47,14 @@
 
   <div class="mb-3">
     <label class="form-label">المورد</label>
-    <select name="Supplier" class="custom-select select2">
-      <% suppliers.forEach(s => { %>
-        <option value="<%= s.id %>" <%= card && card.Supplier === s.id ? 'selected' : '' %>><%= s.name %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="Supplier" class="custom-select select2">
+        <% suppliers.forEach(s => { %>
+          <option value="<%= s.id %>" <%= card && card.Supplier === s.id ? 'selected' : '' %>><%= s.name %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/suppliers/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
 
   <button type="submit" class="btn btn-success">حفظ</button>

--- a/views/drivers/new.ejs
+++ b/views/drivers/new.ejs
@@ -6,11 +6,14 @@
   <% } else { %>
   <div class="mb-3">
     <label class="form-label">المنشأة</label>
-    <select name="FacilityID" class="custom-select select2">
-      <% facilities.forEach(f => { %>
-        <option value="<%= f.FacilityID %>"><%= f.Name %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="FacilityID" class="custom-select select2">
+        <% facilities.forEach(f => { %>
+          <option value="<%= f.FacilityID %>"><%= f.Name %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/facilities/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <% } %>
   <div class="mb-3">

--- a/views/facilities/edit.ejs
+++ b/views/facilities/edit.ejs
@@ -26,11 +26,14 @@
   </div>
   <div class="mb-3">
     <label class="form-label">نوع الترخيص</label>
-    <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
-      <% licenseTypes.forEach(lt => { %>
-        <option value="<%= lt.LicenseTypeID %>" data-name="<%= lt.LicenseTypeNameAR %>" <%= facility.LicenseTypeID === lt.LicenseTypeID ? 'selected' : '' %>><%= lt.LicenseTypeNameAR %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
+        <% licenseTypes.forEach(lt => { %>
+          <option value="<%= lt.LicenseTypeID %>" data-name="<%= lt.LicenseTypeNameAR %>" <%= facility.LicenseTypeID === lt.LicenseTypeID ? 'selected' : '' %>><%= lt.LicenseTypeNameAR %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/license-types/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
     <input type="hidden" name="LicenseType" id="LicenseType" value="<%= facility.LicenseType || '' %>">
   </div>
   <div class="mb-3">

--- a/views/facilities/new.ejs
+++ b/views/facilities/new.ejs
@@ -27,11 +27,14 @@
   </div>
   <div class="mb-3">
     <label class="form-label">نوع الترخيص</label>
-    <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
-      <% licenseTypes.forEach(lt => { %>
-        <option value="<%= lt.LicenseTypeID %>" data-name="<%= lt.LicenseTypeNameAR %>"><%= lt.LicenseTypeNameAR %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="LicenseTypeID" id="LicenseTypeID" class="form-select">
+        <% licenseTypes.forEach(lt => { %>
+          <option value="<%= lt.LicenseTypeID %>" data-name="<%= lt.LicenseTypeNameAR %>"><%= lt.LicenseTypeNameAR %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/license-types/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
     <input type="hidden" name="LicenseType" id="LicenseType">
   </div>
   <div class="mb-3">

--- a/views/models/edit.ejs
+++ b/views/models/edit.ejs
@@ -2,11 +2,14 @@
 <form method="POST" action="/nagl/models/<%= model.ModelID %>">
   <div class="mb-3">
     <label class="form-label">الماركة</label>
-    <select name="BrandID" class="custom-select select2">
-      <% brands.forEach(b => { %>
-        <option value="<%= b.BrandID %>" <%= model.BrandID === b.BrandID ? 'selected' : '' %>><%= b.BrandName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="BrandID" class="custom-select select2">
+        <% brands.forEach(b => { %>
+          <option value="<%= b.BrandID %>" <%= model.BrandID === b.BrandID ? 'selected' : '' %>><%= b.BrandName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/brands/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">اسم الموديل</label>

--- a/views/models/new.ejs
+++ b/views/models/new.ejs
@@ -2,11 +2,14 @@
 <form method="POST" action="/nagl/models">
   <div class="mb-3">
     <label class="form-label">الماركة</label>
-    <select name="BrandID" class="custom-select select2">
-      <% brands.forEach(b => { %>
-        <option value="<%= b.BrandID %>"><%= b.BrandName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="BrandID" class="custom-select select2">
+        <% brands.forEach(b => { %>
+          <option value="<%= b.BrandID %>"><%= b.BrandName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/brands/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">اسم الموديل</label>

--- a/views/vehicles/edit.ejs
+++ b/views/vehicles/edit.ejs
@@ -2,11 +2,14 @@
 <form method="POST" action="/nagl/vehicles/<%= vehicle.ID %>">
   <div class="mb-3">
     <label class="form-label">المنشأة</label>
-    <select name="FacilityID" class="custom-select select2">
-      <% facilities.forEach(f => { %>
-        <option value="<%= f.FacilityID %>" <%= vehicle.FacilityID == f.FacilityID ? 'selected' : '' %>><%= f.Name %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="FacilityID" class="custom-select select2">
+        <% facilities.forEach(f => { %>
+          <option value="<%= f.FacilityID %>" <%= vehicle.FacilityID == f.FacilityID ? 'selected' : '' %>><%= f.Name %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/facilities/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">رقم اللوحة</label>
@@ -18,30 +21,39 @@
   </div>
   <div class="mb-3">
     <label class="form-label">الماركة</label>
-    <select name="BrandID" id="brandSelect" class="custom-select select2">
-      <option value=""></option>
-      <% brands.forEach(b => { %>
-        <option value="<%= b.BrandID %>" <%= vehicle.BrandID == b.BrandID ? 'selected' : '' %>><%= b.BrandName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="BrandID" id="brandSelect" class="custom-select select2">
+        <option value=""></option>
+        <% brands.forEach(b => { %>
+          <option value="<%= b.BrandID %>" <%= vehicle.BrandID == b.BrandID ? 'selected' : '' %>><%= b.BrandName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/brands/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">الطراز</label>
-    <select name="ModelID" class="custom-select select2">
-      <option value=""></option>
-      <% models.forEach(m => { %>
-        <option value="<%= m.ModelID %>" <%= vehicle.ModelID == m.ModelID ? 'selected' : '' %>><%= m.ModelName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="ModelID" class="custom-select select2">
+        <option value=""></option>
+        <% models.forEach(m => { %>
+          <option value="<%= m.ModelID %>" <%= vehicle.ModelID == m.ModelID ? 'selected' : '' %>><%= m.ModelName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/models/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">اللون</label>
-    <select name="ColorID" class="custom-select select2">
-      <option value=""></option>
-      <% colors.forEach(c => { %>
-        <option value="<%= c.ColorID %>" <%= vehicle.ColorID == c.ColorID ? 'selected' : '' %>><%= c.ColorName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="ColorID" class="custom-select select2">
+        <option value=""></option>
+        <% colors.forEach(c => { %>
+          <option value="<%= c.ColorID %>" <%= vehicle.ColorID == c.ColorID ? 'selected' : '' %>><%= c.ColorName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/colors/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">سنة الصنع</label>

--- a/views/vehicles/new.ejs
+++ b/views/vehicles/new.ejs
@@ -5,11 +5,14 @@
     <% if (facilityId) { %>
       <input type="hidden" name="FacilityID" value="<%= facilityId %>">
     <% } else { %>
-      <select name="FacilityID" class="custom-select select2">
-        <% facilities.forEach(f => { %>
-          <option value="<%= f.FacilityID %>" <%= facilityId == f.FacilityID ? 'selected' : '' %>><%= f.Name %></option>
-        <% }) %>
-      </select>
+      <div class="input-group">
+        <select name="FacilityID" class="custom-select select2">
+          <% facilities.forEach(f => { %>
+            <option value="<%= f.FacilityID %>" <%= facilityId == f.FacilityID ? 'selected' : '' %>><%= f.Name %></option>
+          <% }) %>
+        </select>
+        <a href="/nagl/facilities/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+      </div>
     <% } %>
   </div>
   <div class="mb-3">
@@ -22,30 +25,39 @@
   </div>
   <div class="mb-3">
     <label class="form-label">الماركة</label>
-    <select name="BrandID" id="brandSelect" class="custom-select select2">
-      <option value=""></option>
-      <% brands.forEach(b => { %>
-        <option value="<%= b.BrandID %>"><%= b.BrandName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="BrandID" id="brandSelect" class="custom-select select2">
+        <option value=""></option>
+        <% brands.forEach(b => { %>
+          <option value="<%= b.BrandID %>"><%= b.BrandName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/brands/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">الطراز</label>
-    <select name="ModelID" class="custom-select select2">
-      <option value=""></option>
-      <% models.forEach(m => { %>
-        <option value="<%= m.ModelID %>"><%= m.ModelName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="ModelID" class="custom-select select2">
+        <option value=""></option>
+        <% models.forEach(m => { %>
+          <option value="<%= m.ModelID %>"><%= m.ModelName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/models/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">اللون</label>
-    <select name="ColorID" class="custom-select select2">
-      <option value=""></option>
-      <% colors.forEach(c => { %>
-        <option value="<%= c.ColorID %>"><%= c.ColorName %></option>
-      <% }) %>
-    </select>
+    <div class="input-group">
+      <select name="ColorID" class="custom-select select2">
+        <option value=""></option>
+        <% colors.forEach(c => { %>
+          <option value="<%= c.ColorID %>"><%= c.ColorName %></option>
+        <% }) %>
+      </select>
+      <a href="/nagl/colors/new" target="_blank" class="btn btn-outline-secondary btn-icon"><i class="bi bi-plus"></i></a>
+    </div>
   </div>
   <div class="mb-3">
     <label class="form-label">سنة الصنع</label>


### PR DESCRIPTION
## Summary
- add "new" buttons to select controls that open creation forms in a new tab for related tables
- improve facility, vehicle, driver, and model forms with quick links

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fde50e15883319dabf86b1c789593