### PR TITLE
Allow editing driver identity number and validate input

### DIFF
--- a/routes/drivers.js
+++ b/routes/drivers.js
@@ -32,6 +32,9 @@ router.get('/drivers/new', asyncHandler(async (req, res) => {
 // Create driver
 router.post('/drivers', asyncHandler(async (req, res) => {
   const { FacilityID, IdentityNumber, FirstName, LastName, next } = req.body;
+  if (!IdentityNumber) {
+    return res.status(400).send('رقم الهوية مطلوب');
+  }
   const result = await pool.query(
     'INSERT INTO OPC_Driver (FacilityID, IdentityNumber, FirstName, LastName) VALUES (?, ?, ?, ?)',
     [FacilityID, IdentityNumber, FirstName, LastName]

--- a/views/drivers/new.ejs
+++ b/views/drivers/new.ejs
@@ -18,7 +18,11 @@
   <% } %>
   <div class="mb-3">
     <label class="form-label">رقم هوية السائق</label>
+    <% if (identity) { %>
     <input type="text" name="IdentityNumber" class="form-control" value="<%= identity %>" readonly>
+    <% } else { %>
+    <input type="text" name="IdentityNumber" class="form-control" required>
+    <% } %>
   </div>
   <div class="mb-3">
     <label class="form-label">الاسم الأول</label>


### PR DESCRIPTION
## Summary
- Make driver IdentityNumber field editable when no identity query parameter is supplied.
- Validate IdentityNumber in POST /drivers route, returning a clear error if missing.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fecb461d0833184bab593f86a0313