### PR TITLE
Add responsive DataTables control column

### DIFF
--- a/public/js/forms.js
+++ b/public/js/forms.js
@@ -33,7 +33,12 @@ $(function () {
   if ($.fn.DataTable) {
     $('table.data-table').DataTable({
       order: [],
-      responsive: true,
+      responsive: {
+        details: { type: 'column', target: 'tr' }
+      },
+      columnDefs: [
+        { className: 'dtr-control', orderable: false, targets: 0 }
+      ],
       stripeClasses: [],
       pageLength: 10,
       lengthMenu: [10, 20, 50, 100],

--- a/views/brands/index.ejs
+++ b/views/brands/index.ejs
@@ -5,17 +5,19 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الرقم</th>
-      <th>الاسم</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% brands.forEach(b => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= b.BrandID %></pre></td>
+        <th></th>
+        <th>الرقم</th>
+        <th>الاسم</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% brands.forEach(b => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= b.BrandID %></pre></td>
         <td><pre class="codebox"><%= b.BrandName %></pre></td>
         <td>
           <a href="/nagl/brands/<%= b.BrandID %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>

--- a/views/cards/index.ejs
+++ b/views/cards/index.ejs
@@ -5,21 +5,23 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>رقم البطاقة</th>
-      <th>المركبة</th>
-      <th>المنشأة</th>
-      <th class="hide-mobile">تاريخ الإصدار</th>
-      <th class="hide-mobile">تاريخ الانتهاء</th>
-      <th class="hide-mobile">المندوب</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% cards.forEach(c => { %>
+    <thead class="table-light">
       <tr>
-        <td>
+        <th></th>
+        <th>رقم البطاقة</th>
+        <th>المركبة</th>
+        <th>المنشأة</th>
+        <th class="hide-mobile">تاريخ الإصدار</th>
+        <th class="hide-mobile">تاريخ الانتهاء</th>
+        <th class="hide-mobile">المندوب</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% cards.forEach(c => { %>
+        <tr>
+          <td></td>
+          <td>
           <a href="https://s.mnaseb.com/h/OPcard/op.php?token=<%= c.token %>" target="_blank" rel="noopener">
             <pre class="codebox"><%= c.CardNumber %></pre>
           </a>

--- a/views/colors/index.ejs
+++ b/views/colors/index.ejs
@@ -5,17 +5,19 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الرقم</th>
-      <th>الاسم</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% colors.forEach(c => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= c.ColorID %></pre></td>
+        <th></th>
+        <th>الرقم</th>
+        <th>الاسم</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% colors.forEach(c => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= c.ColorID %></pre></td>
         <td><pre class="codebox"><%= c.ColorName %></pre></td>
         <td>
           <a href="/nagl/colors/<%= c.ColorID %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>

--- a/views/drivercards/index.ejs
+++ b/views/drivercards/index.ejs
@@ -5,22 +5,24 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>رقم البطاقة</th>
-      <th>نوع البطاقة</th>
-      <th>السائق</th>
-      <th>المنشأة</th>
-      <th class="hide-mobile">تاريخ الإصدار</th>
-      <th class="hide-mobile">تاريخ الانتهاء</th>
-      <th class="hide-mobile">المندوب</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% cards.forEach(c => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><a href="<%= printUrl %>?token=<%= c.token %>" target="_blank"><%= c.CardNumber %></a></pre></td>
+        <th></th>
+        <th>رقم البطاقة</th>
+        <th>نوع البطاقة</th>
+        <th>السائق</th>
+        <th>المنشأة</th>
+        <th class="hide-mobile">تاريخ الإصدار</th>
+        <th class="hide-mobile">تاريخ الانتهاء</th>
+        <th class="hide-mobile">المندوب</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% cards.forEach(c => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><a href="<%= printUrl %>?token=<%= c.token %>" target="_blank"><%= c.CardNumber %></a></pre></td>
         <td><pre class="codebox"><%= c.CardType %></pre></td>
         <td><pre class="codebox"><%= c.FirstName || '' %></pre></td>
         <td><pre class="codebox"><%= c.Name || '' %></pre></td>

--- a/views/drivers/index.ejs
+++ b/views/drivers/index.ejs
@@ -21,20 +21,22 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الرقم</th>
-      <th>الاسم</th>
-      <th>رقم الهوية</th>
-      <th>المنشأة</th>
-      <th>تفاصيل</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% drivers.forEach(d => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= d.DriverID %></pre></td>
+        <th></th>
+        <th>الرقم</th>
+        <th>الاسم</th>
+        <th>رقم الهوية</th>
+        <th>المنشأة</th>
+        <th>تفاصيل</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% drivers.forEach(d => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= d.DriverID %></pre></td>
         <td><pre class="codebox"><%= d.FirstName %> <%= d.LastName %></pre></td>
         <td><pre class="codebox"><%= d.IdentityNumber || '' %></pre></td>
         <td><pre class="codebox"><%= d.FacilityName || '' %></pre></td>

--- a/views/facilities/index.ejs
+++ b/views/facilities/index.ejs
@@ -5,18 +5,20 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الاسم</th>
-      <th>رقم الهوية</th>
-      <th>نوع الترخيص</th>
-      <th>تعديل</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% facilities.forEach(f => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= f.Name %></pre></td>
+        <th></th>
+        <th>الاسم</th>
+        <th>رقم الهوية</th>
+        <th>نوع الترخيص</th>
+        <th>تعديل</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% facilities.forEach(f => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= f.Name %></pre></td>
         <td><pre class="codebox"><%= f.IdentityNumber %></pre></td>
         <td><pre class="codebox"><%= f.LicenseType || '' %></pre></td>
         <td><a href="/nagl/facilities/<%= f.FacilityID %>/edit">تعديل</a></td>

--- a/views/licenseTypes/index.ejs
+++ b/views/licenseTypes/index.ejs
@@ -5,18 +5,20 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الرقم</th>
-      <th>الاسم بالعربية</th>
-      <th>الاسم بالإنجليزية</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% licenseTypes.forEach(lt => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= lt.LicenseTypeID %></pre></td>
+        <th></th>
+        <th>الرقم</th>
+        <th>الاسم بالعربية</th>
+        <th>الاسم بالإنجليزية</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% licenseTypes.forEach(lt => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= lt.LicenseTypeID %></pre></td>
         <td><pre class="codebox"><%= lt.LicenseTypeNameAR %></pre></td>
         <td><pre class="codebox"><%= lt.LicenseTypeNameEN || '' %></pre></td>
         <td>

--- a/views/models/index.ejs
+++ b/views/models/index.ejs
@@ -5,17 +5,19 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الرقم</th>
-      <th>الاسم</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% models.forEach(m => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= m.ModelID %></pre></td>
+        <th></th>
+        <th>الرقم</th>
+        <th>الاسم</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% models.forEach(m => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= m.ModelID %></pre></td>
         <td><pre class="codebox"><%= m.ModelName %></pre></td>
         <td>
           <a href="/nagl/models/<%= m.ModelID %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>

--- a/views/suppliers/index.ejs
+++ b/views/suppliers/index.ejs
@@ -5,17 +5,19 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>الرقم</th>
-      <th>الاسم</th>
-      <th>إجراءات</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% suppliers.forEach(s => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= s.id %></pre></td>
+        <th></th>
+        <th>الرقم</th>
+        <th>الاسم</th>
+        <th>إجراءات</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% suppliers.forEach(s => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= s.id %></pre></td>
         <td><pre class="codebox"><%= s.name %></pre></td>
         <td>
           <a href="/nagl/suppliers/<%= s.id %>/edit" class="btn btn-sm btn-outline-primary">تعديل</a>

--- a/views/vehicles/index.ejs
+++ b/views/vehicles/index.ejs
@@ -5,18 +5,20 @@
 </div>
 <div class="table-responsive">
 <table class="table table-bordered table-striped data-table results-table">
-  <thead class="table-light">
-    <tr>
-      <th>رقم اللوحة</th>
-      <th>الرقم التسلسلي</th>
-      <th>المنشأة</th>
-      <th>تعديل</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% vehicles.forEach(v => { %>
+    <thead class="table-light">
       <tr>
-        <td><pre class="codebox"><%= v.PlateNumber || '' %></pre></td>
+        <th></th>
+        <th>رقم اللوحة</th>
+        <th>الرقم التسلسلي</th>
+        <th>المنشأة</th>
+        <th>تعديل</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% vehicles.forEach(v => { %>
+        <tr>
+          <td></td>
+          <td><pre class="codebox"><%= v.PlateNumber || '' %></pre></td>
         <td><pre class="codebox"><%= v.SerialNumber || '' %></pre></td>
         <td><pre class="codebox"><%= v.Name || '' %></pre></td>
         <td><a href="/nagl/vehicles/<%= v.ID %>/edit">تعديل</a></td>


### PR DESCRIPTION
## Summary
- configure DataTables to use a responsive control column
- add empty control cells to every listing table for row details

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689001767fa083319bfc61e282d5ebf2